### PR TITLE
Use new configuration mechanism

### DIFF
--- a/PowerBIServiceBackup/Helpers/UtilityHelper.cs
+++ b/PowerBIServiceBackup/Helpers/UtilityHelper.cs
@@ -1,30 +1,32 @@
-﻿using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
-using System.Configuration;
-
-namespace PowerBIServiceBackup.Helpers
+﻿namespace PowerBIServiceBackup.Helpers
 {
-    public static class UtilityHelper
+	using Infrastructure;
+	using Infrastructure.Config;
+	using Microsoft.Extensions.DependencyInjection;
+
+	public static class UtilityHelper
     {
+		private static readonly AppSettings Settings = ServiceProviderConfiguration.GetServiceProvider().GetService<AppSettings>();
+
         public static string CheckConfig()
         {
-            if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["PowerBILogin"]))
+            if (string.IsNullOrEmpty(Settings.AzureAd.PowerBILogin))
                 return "Setting : PowerBILogin is empty or doesn't exist";
-            if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["PowerBIPassword"]))
+            if (string.IsNullOrEmpty(Settings.AzureAd.PowerBIPassword))
                 return "Setting : PowerBIPassword is empty or doesn't exist";
-            if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["AuthenticationContextUrl"]))
+            if (string.IsNullOrEmpty(Settings.AzureAd.AuthenticationContextUrl))
                 return "Setting : AuthenticationContextUrl is empty or doesn't exist";
-            if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["PowerBIRessourceUrl"]))
+            if (string.IsNullOrEmpty(Settings.AzureAd.PowerBIRessourceUrl))
                 return "Setting : PowerBIRessourceUrl is empty or doesn't exist";
-            if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["ClientId"]))
+            if (string.IsNullOrEmpty(Settings.AzureAd.ClientId))
                 return "Setting : ClientId is empty or doesn't exist";
-            if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["PowerBIApi"]))
+            if (string.IsNullOrEmpty(Settings.PowerBIApi))
                 return "Setting : PowerBIApi is empty or doesn't exist";
-            if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["BlobContainerName"]))
+            if (string.IsNullOrEmpty(Settings.BlobStorage.BlobContainerName))
                 return "Setting : BlobContainerName is empty or doesn't exist";
-            if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["BlobConnectionString"]))
+            if (string.IsNullOrEmpty(Settings.BlobStorage.BlobConnectionString))
                 return "Setting : BlobConnectionString is empty or doesn't exist";
-            if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["MaxDegreeOfParallelism"]))
+            if (Settings.MaxDegreeOfParallelism == null)
                 return "Setting : MaxDegreeOfParallelism is empty or doesn't exist";
 
             return null;

--- a/PowerBIServiceBackup/Infrastructure/Config/AppSettings.cs
+++ b/PowerBIServiceBackup/Infrastructure/Config/AppSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace PowerBIServiceBackup.Infrastructure.Config
+{
+	public class AppSettings
+	{
+		public AzureAd AzureAd { get; set; }
+
+		public BlobStorage BlobStorage { get; set; }
+
+		public string PowerBIApi { get; set; }
+
+		public int? MaxDegreeOfParallelism { get; set; }
+	}
+}

--- a/PowerBIServiceBackup/Infrastructure/Config/AzureAd.cs
+++ b/PowerBIServiceBackup/Infrastructure/Config/AzureAd.cs
@@ -1,0 +1,11 @@
+﻿namespace PowerBIServiceBackup.Infrastructure.Config
+{
+	public class AzureAd
+	{
+		public string AuthenticationContextUrl { get; set; }
+		public string PowerBIRessourceUrl { get; set; }
+		public string ClientId { get; set; }
+		public string PowerBILogin { get; set; }
+		public string PowerBIPassword { get; set; }
+	}
+}

--- a/PowerBIServiceBackup/Infrastructure/Config/BlobStorage.cs
+++ b/PowerBIServiceBackup/Infrastructure/Config/BlobStorage.cs
@@ -1,0 +1,8 @@
+﻿namespace PowerBIServiceBackup.Infrastructure.Config
+{
+	public class BlobStorage
+	{
+		public string BlobContainerName { get; set; }
+		public string BlobConnectionString { get; set; }
+	}
+}

--- a/PowerBIServiceBackup/Infrastructure/ServiceProviderConfiguration.cs
+++ b/PowerBIServiceBackup/Infrastructure/ServiceProviderConfiguration.cs
@@ -31,9 +31,9 @@
 		{
 			var config = new ConfigurationBuilder()
 						 .SetBasePath(Directory.GetCurrentDirectory())
-						 // you might want to change this, to your real config file.
-						 .AddJsonFile("sample_local.settings", true, true)
-						 .AddEnvironmentVariables()
+                         // you might want to change this, to your real config file.
+                         .AddJsonFile("local.settings.json", true, true)
+                         .AddEnvironmentVariables()
 						 .Build();
 
 			return config;

--- a/PowerBIServiceBackup/Infrastructure/ServiceProviderConfiguration.cs
+++ b/PowerBIServiceBackup/Infrastructure/ServiceProviderConfiguration.cs
@@ -1,0 +1,54 @@
+﻿namespace PowerBIServiceBackup.Infrastructure
+{
+	using System;
+	using System.IO;
+	using Config;
+	using Microsoft.Extensions.Configuration;
+	using Microsoft.Extensions.DependencyInjection;
+
+	internal static class ServiceProviderConfiguration
+	{
+
+		private static readonly Lazy<IServiceProvider> ServiceProvider = new Lazy<IServiceProvider>(BuildServiceProvider);
+		
+		private static IServiceProvider BuildServiceProvider()
+		{
+			var services = new ServiceCollection();
+
+			// treats config as a singleton
+			var config = GetConfiguration();
+			services.AddSingleton(config);
+
+			// bind config to a custom class to avoid magic string. 
+			var appSettings = GetAppSettings(config);
+			services.AddSingleton(appSettings);
+
+            return services.BuildServiceProvider();
+        }
+
+
+		private static IConfigurationRoot GetConfiguration()
+		{
+			var config = new ConfigurationBuilder()
+						 .SetBasePath(Directory.GetCurrentDirectory())
+						 // you might want to change this, to your real config file.
+						 .AddJsonFile("sample_local.settings", true, true)
+						 .AddEnvironmentVariables()
+						 .Build();
+
+			return config;
+		}
+
+		private static AppSettings GetAppSettings(IConfiguration config)
+		{
+			var appSettings = new AppSettings();
+			config.Bind(appSettings);
+			return appSettings;
+		}
+
+		public static IServiceProvider GetServiceProvider()
+		{
+			return ServiceProvider.Value;
+		}
+    }
+}

--- a/PowerBIServiceBackup/PowerBIServiceBackup.csproj
+++ b/PowerBIServiceBackup/PowerBIServiceBackup.csproj
@@ -4,10 +4,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.13" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.14" />
     <PackageReference Include="Microsoft.PowerBI.Api" Version="2.0.14" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
@@ -15,6 +22,10 @@
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
     <None Update="sample_local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/PowerBIServiceBackup/sample_local.settings.json
+++ b/PowerBIServiceBackup/sample_local.settings.json
@@ -2,15 +2,19 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsDashboard": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;",
-    "AzureWebJobsStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;",
-    "PowerBILogin": "xxx@xxx.xxx",
-    "PowerBIPassword": "xxxxxxxxxx",
+    "AzureWebJobsStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;"
+  },
+  "MaxDegreeOfParallelism": 5,
+  "PowerBIApi": "https://api.powerbi.com",
+  "AzureAd": {
     "AuthenticationContextUrl": "https://login.windows.net/common/oauth2/authorize/",
     "PowerBIRessourceUrl": "https://analysis.windows.net/powerbi/api",
     "ClientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx",
-    "PowerBIApi": "https://api.powerbi.com",
+    "PowerBILogin": "xxx@xxx.xxx",
+    "PowerBIPassword": "xxxxxxxxxx"
+  },
+  "BlobStorage": {
     "BlobContainerName": "pbix-backups",
-    "BlobConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;",
-    "MaxDegreeOfParallelism": 5
+    "BlobConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;"
   }
 }


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1&tabs=basicconfiguration, this PR aims to drop ConfigurationManager usage in favor of new automatic config binding.
In addition, i've initiated an ioc skeleton that could/should be used instead of static references all around.